### PR TITLE
fix: style bridged token icons

### DIFF
--- a/src/css/transfer-form.css
+++ b/src/css/transfer-form.css
@@ -197,5 +197,26 @@
 
 .token-selector .token-list img {
   width: 1.5em;
-  margin-right: 1em;
+}
+
+.token-in-list-name {
+  margin-left: 1em;
+}
+
+.bridged-token-icon {
+  border: 2px solid #fb5152;
+  border-radius: 50%;
+}
+
+.bridged-token {
+  position: relative;
+  display: inline-block;
+}
+.bridged-token:before {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: rgba(254, 170, 170, 0.2);
+  border-radius: 50%;
 }

--- a/src/html/erc20-form.html
+++ b/src/html/erc20-form.html
@@ -250,7 +250,9 @@
           />
           <span>
             <img src="${token.icon || "ethereum.svg"}" alt="" />
-            ${token.name}
+            <span class="token-in-list-name">
+              ${token.name}
+            </span>
           </span>
           <span>
             ${window.utils.formatLargeNum(token.balance, token.decimals)}

--- a/src/html/erc20n-form.html
+++ b/src/html/erc20n-form.html
@@ -238,8 +238,12 @@
             value="${token.address}"
           />
           <span>
-            <img src="${token.nep141.icon || "near.svg"}" alt="" />
-            ${token.nep141.name}
+            <div class="bridged-token">
+              <img class="bridged-token-icon" src="${token.icon || "near.svg"}" alt="" />
+            </div>
+            <span class="token-in-list-name">
+              ${token.nep141.name}
+            </span>
           </span>
           <span>
             ${window.utils.formatLargeNum(token.nep141.balance, token.decimals)}


### PR DESCRIPTION
Fix to get icons from trustwallet: https://github.com/aurora-is-near/rainbow-bridge-client/pull/31
Add styling to bridged icons
![image](https://user-images.githubusercontent.com/29397451/115832325-bae5ee00-a44d-11eb-8b02-536097fbb602.png)
![image](https://user-images.githubusercontent.com/29397451/115832363-c802dd00-a44d-11eb-8410-95b78af2b7ed.png)
https://github.com/aurora-is-near/rainbow-bridge-frontend/issues/159
https://github.com/aurora-is-near/rainbow-bridge-frontend/issues/117