### PR TITLE
fix: enable remove transfer before lock transaction is made

### DIFF
--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -589,7 +589,10 @@
               `<button class="button--cta button-size--small" data-behavior="transferCallToAction">${transfer.callToAction}</button>`
           )}
           ${window.dom.toString(
-            transfer.status === "completed" &&
+            (transfer.status === "completed" || // transfer completed
+              (transfer.type === '@near-eth/nep141-erc20/natural-erc20/sendToNear' && !transfer.completedStep) || // transfer from Ethereum not yet approved
+              (transfer.completedStep === 'approve-natural-erc20-to-nep141' && transfer.status === 'action-needed') || // approved but not transfered (not yet locked)
+              (transfer.completedStep === 'approve-natural-erc20-to-nep141' && transfer.status === 'failed')) && // approved but not transfered (lock failed)
               `<button class="button--delete button-size--small" data-behavior="deleteTransfer"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M2 4H3.33333H14" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                 <path d="M5.3335 4.00004V2.66671C5.3335 2.31309 5.47397 1.97395 5.72402 1.7239C5.97407 1.47385 6.31321 1.33337 6.66683 1.33337H9.3335C9.68712 1.33337 10.0263 1.47385 10.2763 1.7239C10.5264 1.97395 10.6668 2.31309 10.6668 2.66671V4.00004M12.6668 4.00004V13.3334C12.6668 13.687 12.5264 14.0261 12.2763 14.2762C12.0263 14.5262 11.6871 14.6667 11.3335 14.6667H4.66683C4.31321 14.6667 3.97407 14.5262 3.72402 14.2762C3.47397 14.0261 3.3335 13.687 3.3335 13.3334V4.00004H12.6668Z" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
Fix for https://github.com/aurora-is-near/rainbow-bridge-frontend/issues/224
Transfer can be removed before the sendToNear lock step.
Prevents deadlock if user spends the tokens in 2 places at once.
![image](https://user-images.githubusercontent.com/29397451/116018018-0d0c5680-a67c-11eb-9487-09357ee3af8f.png)
![image](https://user-images.githubusercontent.com/29397451/116018027-139ace00-a67c-11eb-93da-fc1e87579961.png)
![image](https://user-images.githubusercontent.com/29397451/116018037-1d243600-a67c-11eb-88df-2169c2497ebf.png)
