### PR TITLE
Copy refinements for TXN modals

### DIFF
--- a/src/html/alert-banner.html
+++ b/src/html/alert-banner.html
@@ -42,7 +42,7 @@
     justify-content: center;
     font-size: var(--fs-micro);
     font-weight: var(--fw-regular);
-    padding: var(--spacing-m);
+    padding: var(--spacing-s);
   }
 
   .banner svg {

--- a/src/html/bridge-erc20-form.html
+++ b/src/html/bridge-erc20-form.html
@@ -1,23 +1,30 @@
 <div>
-  <form data-behavior="bridgeErc20Form" class="container" style="display:none">
-    <h1 style="background: url(img/unbridged.svg) top center no-repeat; font-size: 1.5em; padding: 12rem 0 2.5rem">
+  <form data-behavior="bridgeErc20Form" class="container" style="display: none">
+    <h1
+      style="
+        background: url(img/unbridged.svg) top center no-repeat;
+        font-size: 1.5em;
+        padding: 12rem 0 2.5rem;
+      "
+    >
       Set up <strong data-behavior="erc20Name"></strong> on NEAR
     </h1>
     <p>
       The <strong data-behavior="erc20Name"></strong>
       <a
         href="https://eips.ethereum.org/EIPS/eip-20"
-        target="_blank" rel="noopener noreferrer"
-      >ERC20</a>
+        target="_blank"
+        rel="noopener noreferrer"
+        >ERC20</a
+      >
       token has not yet been bridged.
     </p>
     <p>
-      This is the first time the <strong data-behavior="erc20Name"></strong> token is being transferred to NEAR.
-      This requires a small, one-time setup fee of about 3 $NEAR.
+      This is the first time the
+      <strong data-behavior="erc20Name"></strong> token is being transferred to
+      NEAR. This requires a small, one-time setup fee of about 3 $NEAR.
     </p>
-    <button style="margin-top: 3em">
-      Bridge it!
-    </button>
+    <button style="margin-top: 3em">Bridge it!</button>
     <button type="button" class="cancel" data-behavior="bridgeErc20Cancel">
       Cancel
     </button>
@@ -41,7 +48,7 @@
         You will be redirected to NEAR Wallet to complete your transaction.
       </p>
       <p class="modal__message">
-        Please do not go back or close the window until the process is complete.
+        Keep this window open until the process is complete.
       </p>
       <button data-behavior="nearBridgeTxConfirmButton" class="full-width">
         Continue to NEAR Wallet
@@ -51,66 +58,65 @@
 </div>
 
 <script>
-  window.addEventListener('load', function handleSelectErc20Events () {
+  window.addEventListener("load", function handleSelectErc20Events() {
     const confirmBridgeTxButton = window.dom.find("nearBridgeTxConfirmButton");
-    window.dom.find('bridgeErc20Form').onsubmit = async function bridgeIt (e) {
-      e.preventDefault()
-      window.dom.show("nearBridgeTxModal")
-    }
+    window.dom.find("bridgeErc20Form").onsubmit = async function bridgeIt(e) {
+      e.preventDefault();
+      window.dom.show("nearBridgeTxModal");
+    };
     confirmBridgeTxButton.onclick = async () => {
-      confirmBridgeTxButton.disabled = true
+      confirmBridgeTxButton.disabled = true;
       try {
-        const { erc20, erc20n } = window.urlParams.get('erc20', 'erc20n')
-        const erc20Address = erc20 || erc20n
-        await window.nep141Xerc20.bridgedNep141.deploy(erc20Address)
+        const { erc20, erc20n } = window.urlParams.get("erc20", "erc20n");
+        const erc20Address = erc20 || erc20n;
+        await window.nep141Xerc20.bridgedNep141.deploy(erc20Address);
       } catch (e) {
         // only hide if error, show until redirect happens
-        console.error(e)
+        console.error(e);
         alert(
-          "Something went wrong! " +
-          "Check your browser console for more info."
+          "Something went wrong! " + "Check your browser console for more info."
         );
-        window.dom.hide("nearBridgeTxModal")
-        confirmBridgeTxButton.disabled = false
+        window.dom.hide("nearBridgeTxModal");
+        confirmBridgeTxButton.disabled = false;
       }
-    }
+    };
 
-    window.dom.find('bridgeErc20Cancel').onclick = () => {
-      window.dom.hide('bridgeErc20Form')
-      window.urlParams.clear()
-      window.render()
-    }
-  })
+    window.dom.find("bridgeErc20Cancel").onclick = () => {
+      window.dom.hide("bridgeErc20Form");
+      window.urlParams.clear();
+      window.render();
+    };
+  });
 
-  async function renderBridgeErc20 () {
-    if (!(window.ethInitialized && window.nearInitialized)) return
-    if (!window.isValidEthNetwork) return
+  async function renderBridgeErc20() {
+    if (!(window.ethInitialized && window.nearInitialized)) return;
+    if (!window.isValidEthNetwork) return;
 
-    const { erc20, erc20n } = window.urlParams.get('erc20', 'erc20n')
-    const erc20Address = erc20 || erc20n
+    const { erc20, erc20n } = window.urlParams.get("erc20", "erc20n");
+    const erc20Address = erc20 || erc20n;
 
     if (!erc20Address) {
-      window.dom.hide('bridgeErc20Form')
-      return
+      window.dom.hide("bridgeErc20Form");
+      return;
     }
 
-    let token
+    let token;
     try {
-      token = await window.utils.getErc20Data(erc20Address)
+      token = await window.utils.getErc20Data(erc20Address);
     } catch (e) {
       // error message filled in by other components
-      window.dom.hide('bridgeErc20Form')
-      return
+      window.dom.hide("bridgeErc20Form");
+      return;
     }
 
     if (token.nep141.balance !== null) {
-      window.dom.hide('bridgeErc20Form')
-      return
+      window.dom.hide("bridgeErc20Form");
+      return;
     }
 
-    window.dom.fill('erc20Name').with(token.name)
-    window.dom.show('bridgeErc20Form')
+    window.dom.fill("erc20Name").with(token.name);
+    window.dom.show("bridgeErc20Form");
   }
 
-  window.renderers.push(renderBridgeErc20)
+  window.renderers.push(renderBridgeErc20);
 </script>

--- a/src/html/erc20-form.html
+++ b/src/html/erc20-form.html
@@ -14,10 +14,19 @@
       </header>
       <div class="inputs">
         <input type="hidden" name="erc20" data-behavior="erc20Address" />
-        <button class="selectButton" type="button" data-behavior="erc20SelectButton">
+        <button
+          class="selectButton"
+          type="button"
+          data-behavior="erc20SelectButton"
+        >
           Select ERC20
         </button>
-        <button class="maxAmount" type="button" data-behavior="useMaxErc20" style="display: none;">
+        <button
+          class="maxAmount"
+          type="button"
+          data-behavior="useMaxErc20"
+          style="display: none"
+        >
           Use Max
         </button>
         <input
@@ -77,7 +86,12 @@
       <button disabled data-behavior="erc20Submit" class="full-width">
         Approve transfer
       </button>
-      <button id="erc20Cancel" type="button" class="cancel" data-behavior="goHome">
+      <button
+        id="erc20Cancel"
+        type="button"
+        class="cancel"
+        data-behavior="goHome"
+      >
         Cancel
       </button>
     </footer>
@@ -118,20 +132,23 @@
       </form>
     </div>
   </div>
-  <div data-behavior="startTransferToNearModal" class="modal" style="display: none">
+  <div
+    data-behavior="startTransferToNearModal"
+    class="modal"
+    style="display: none"
+  >
     <div class="modal__container">
       <div class="modal-image__container">
         <img src="img/eth-wallet-sig.svg" alt="" class="modal__image" />
       </div>
       <h1 class="modal__heading">Confirm Ethereum Transaction</h1>
       <p class="modal__message">
-        Transfers are a two-step process, requiring confirmations in both your Ethereum and NEAR wallets.
+        Transfers require confirmation from both your Ethereum and NEAR wallets
+        and cannot be cancelled once initiated.
       </p>
       <p class="modal__message">
-        After confirming with your Ethereum wallet, you’ll need to return about 10 minutes later to confirm with your NEAR wallet.
-      </p>
-      <p class="modal__message">
-        Once initiated from Ethereum, the transfer can not be canceled.
+        Once the initial transfer has been confirmed with your Ethereum wallet,
+        you’ll need to return later (~10min) to finalize with your NEAR wallet.
       </p>
     </div>
   </div>
@@ -160,43 +177,50 @@
     }
 
     select.onclick = () => {
-      window.urlParams.set({ erc20: '' })
-      window.dom.find("erc20FreeForm").value = ''
-      window.dom.find("erc20FreeForm").classList.remove("error")
-      erc20Address = ''
-      window.dom.fill("erc20AddressError").with("")
-      window.dom.hide("erc20AddressError")
-      window.dom.show("erc20Modal")
-      window.dom.hide('erc20Info')
-      amount.value = ''
-      window.dom.find("erc20SelectButton").classList.remove("selected")
-      window.dom.fill("erc20SelectButton").with("Select ERC20")
-      window.dom.hide("useMaxErc20")
-      amount.disabled = true
-    }
+      window.urlParams.set({ erc20: "" });
+      window.dom.find("erc20FreeForm").value = "";
+      window.dom.find("erc20FreeForm").classList.remove("error");
+      erc20Address = "";
+      window.dom.fill("erc20AddressError").with("");
+      window.dom.hide("erc20AddressError");
+      window.dom.show("erc20Modal");
+      window.dom.hide("erc20Info");
+      amount.value = "";
+      window.dom.find("erc20SelectButton").classList.remove("selected");
+      window.dom.fill("erc20SelectButton").with("Select ERC20");
+      window.dom.hide("useMaxErc20");
+      amount.disabled = true;
+    };
 
     function enableOrDisableErc20() {
-      window.dom.show("useMaxErc20")
-      const decimalBalance = window.Decimal(window.dom.find("erc20Balance").innerHTML)
-      const decimalAllowance = window.Decimal(window.dom.find("erc20Allowance").innerHTML)
-      const decimalAmount = window.Decimal(amount.value)
-      if (decimalAmount.isZero() || decimalAmount.comparedTo(decimalBalance) === 1)
+      window.dom.show("useMaxErc20");
+      const decimalBalance = window.Decimal(
+        window.dom.find("erc20Balance").innerHTML
+      );
+      const decimalAllowance = window.Decimal(
+        window.dom.find("erc20Allowance").innerHTML
+      );
+      const decimalAmount = window.Decimal(amount.value);
+      if (
+        decimalAmount.isZero() ||
+        decimalAmount.comparedTo(decimalBalance) === 1
+      )
         // decimalAmount is bigger than decimalBalance
-        submit.disabled = true
-      else submit.disabled = false
+        submit.disabled = true;
+      else submit.disabled = false;
       if (decimalAmount.comparedTo(decimalAllowance) === 1)
         // decimalAmount is bigger than decimalAllowance
-        submit.innerHTML = "Approve transfer"
-      else submit.innerHTML = "Submit transfer"
+        submit.innerHTML = "Approve transfer";
+      else submit.innerHTML = "Submit transfer";
     }
 
     maxAmount.onclick = () => {
       amount.value = window.dom.find("erc20Balance").innerHTML;
-      enableOrDisableErc20()
-      window.dom.hide("useMaxErc20")
-    }
+      enableOrDisableErc20();
+      window.dom.hide("useMaxErc20");
+    };
 
-    amount.onkeyup = enableOrDisableErc20
+    amount.onkeyup = enableOrDisableErc20;
 
     window.dom.find(
       "sendNaturalErc20Form"
@@ -205,7 +229,7 @@
 
       disableForm();
 
-      window.dom.show("startTransferToNearModal")
+      window.dom.show("startTransferToNearModal");
       try {
         await window.nep141Xerc20.naturalErc20.sendToNear({
           amount: amount.value,
@@ -217,7 +241,7 @@
         alert("Something went wrong!\n" + e.message);
         throw e;
       } finally {
-        window.dom.hide("startTransferToNearModal")
+        window.dom.hide("startTransferToNearModal");
         // re-enable the form, whether the call succeeded or failed
         enableForm();
       }
@@ -235,16 +259,16 @@
     });
   });
 
-  function ownedErc20OnTop (token1, token2) {
-    if (token1.balance === '0' && token2.balance !== '0') {
-      return 1
-    } else if (token1.balance !== '0' && token2.balance === '0') {
-      return -1
+  function ownedErc20OnTop(token1, token2) {
+    if (token1.balance === "0" && token2.balance !== "0") {
+      return 1;
+    } else if (token1.balance !== "0" && token2.balance === "0") {
+      return -1;
     }
-    return 0
+    return 0;
   }
 
-  async function fillErc20List () {
+  async function fillErc20List() {
     if (!window.ethInitialized) return;
     if (!window.isValidEthNetwork) return;
     if (window.urlParams.get("erc20") === null) return;
@@ -252,8 +276,10 @@
     const allTokens = await window.utils.getAllErc20s();
 
     window.dom.fill("erc20List").with(
-      Object.values(allTokens).sort(ownedErc20OnTop).map(
-        (token) => `
+      Object.values(allTokens)
+        .sort(ownedErc20OnTop)
+        .map(
+          (token) => `
         <label class="space-between">
           <input
             type="radio"
@@ -270,7 +296,7 @@
           </span>
         </label>
       `
-      )
+        )
     );
   }
 
@@ -302,12 +328,12 @@
       window.dom.fill("erc20SelectButton").with("Select ERC20");
       window.dom.hide("erc20Info");
       window.dom.show("sendNaturalErc20");
-      window.dom.hide("useMaxErc20")
+      window.dom.hide("useMaxErc20");
       return;
     }
 
     window.dom.find("erc20Address").value = erc20Address;
-    window.dom.show("useMaxErc20")
+    window.dom.show("useMaxErc20");
 
     let token;
     try {
@@ -329,7 +355,7 @@
     }
 
     // getErc20Data succeeded so remember this token if not already in storage
-    window.utils.rememberCustomErc20(erc20Address)
+    window.utils.rememberCustomErc20(erc20Address);
 
     if (token.nep141.balance === null) {
       window.dom.hide("sendNaturalErc20");
@@ -360,15 +386,17 @@
     if (token.balance) amount.disabled = false;
     else amount.disabled = true;
 
-    amount.step = Number(Decimal(10).pow(-token.decimals).toFixed())
+    amount.step = Number(Decimal(10).pow(-token.decimals).toFixed());
     // NOTE: the html input field makes the comparison on rounded numbers
     // So the max check is not precise for very small decimals.
     // For example if the balance is 500003.0100900000011, then the input field will allow a max of
     // only 500003.01009
     amount.max = Number(
-      new window.Decimal(token.balance).times(Decimal(10).pow(-token.decimals)).toFixed()
-    )
-    amount.min = Number(Decimal(10).pow(-token.decimals).toFixed())
+      new window.Decimal(token.balance)
+        .times(Decimal(10).pow(-token.decimals))
+        .toFixed()
+    );
+    amount.min = Number(Decimal(10).pow(-token.decimals).toFixed());
     window.dom.show("erc20Info", "flex");
     amount.focus();
   }

--- a/src/html/erc20n-form.html
+++ b/src/html/erc20n-form.html
@@ -14,10 +14,19 @@
       </header>
       <div class="inputs">
         <input type="hidden" name="erc20n" data-behavior="erc20nAddress" />
-        <button class="selectButton" type="button" data-behavior="erc20nSelectButton">
+        <button
+          class="selectButton"
+          type="button"
+          data-behavior="erc20nSelectButton"
+        >
           Select token
         </button>
-        <button class="maxAmount" type="button" data-behavior="useMaxErc20n" style="display: none;">
+        <button
+          class="maxAmount"
+          type="button"
+          data-behavior="useMaxErc20n"
+          style="display: none"
+        >
           Use Max
         </button>
         <input
@@ -67,7 +76,12 @@
       <button disabled data-behavior="erc20nSubmit" class="full-width">
         Submit transfer
       </button>
-      <button id="erc20nCancel" type="button" class="cancel" data-behavior="goHome">
+      <button
+        id="erc20nCancel"
+        type="button"
+        class="cancel"
+        data-behavior="goHome"
+      >
         Cancel
       </button>
     </footer>
@@ -107,7 +121,11 @@
       </form>
     </div>
   </div>
-  <div data-behavior="startTransferToEthereumModal" class="modal" style="display: none">
+  <div
+    data-behavior="startTransferToEthereumModal"
+    class="modal"
+    style="display: none"
+  >
     <div class="modal__container">
       <nav class="modal__nav">
         <button
@@ -123,16 +141,19 @@
       </div>
       <h1 class="modal__heading">Confirm NEAR Transaction</h1>
       <p class="modal__message">
-        Transfers are a two-step process, requiring confirmations in both your NEAR and Ethereum wallets.
+        Transfers require confirmation from both your Ethereum and NEAR wallets
+        and cannot be cancelled once initiated.
       </p>
       <p class="modal__message">
-        After confirming with your NEAR wallet, you’ll need to return about 24 hours later to confirm with your Ethereum wallet.
+        Once the initial transfer has been confirmed with your NEAR wallet,
+        you’ll need to return later (~24hr) to finalize with your Ethereum
+        wallet.
       </p>
       <p class="modal__message">
-        Note that when gas is expensive on Ethereum — say 100 Gwei — the transaction could cost around 0.05 ETH, and once initiated from NEAR, the transfer can not be canceled.
+        Transaction costs may vary due to Ethereum network congestion.
       </p>
       <p class="modal__message">
-        You will be redirected to NEAR Wallet to complete your transaction. Please do not go back or close the NEAR Wallet window until the transaction is complete.
+        You will be redirected to NEAR Wallet to complete your transaction.
       </p>
       <button data-behavior="erc20nConfirmSubmit" class="full-width">
         Continue to NEAR Wallet
@@ -148,7 +169,7 @@
     const select = window.dom.find("erc20nSelectButton");
     const submit = window.dom.find("erc20nSubmit");
     const confirmSubmit = window.dom.find("erc20nConfirmSubmit");
-    const cancel = document.getElementById("erc20nCancel")
+    const cancel = document.getElementById("erc20nCancel");
 
     function disableForm() {
       amount.disabled = true;
@@ -165,46 +186,51 @@
     }
 
     select.onclick = () => {
-      window.urlParams.set({ erc20n: '' })
-      window.dom.find('erc20nFreeForm').value = ''
-      window.dom.find("erc20nFreeForm").classList.remove("error")
-      erc20nAddress = ''
-      window.dom.fill("erc20nAddressError").with("")
-      window.dom.hide("erc20nAddressError")
-      window.dom.show('erc20nModal')
-      window.dom.hide('erc20nInfo')
-      amount.value = ''
-      window.dom.find("erc20nSelectButton").classList.remove("selected")
-      window.dom.fill("erc20nSelectButton").with("Select token")
-      window.dom.hide("useMaxErc20n")
-      amount.disabled = true
-    }
+      window.urlParams.set({ erc20n: "" });
+      window.dom.find("erc20nFreeForm").value = "";
+      window.dom.find("erc20nFreeForm").classList.remove("error");
+      erc20nAddress = "";
+      window.dom.fill("erc20nAddressError").with("");
+      window.dom.hide("erc20nAddressError");
+      window.dom.show("erc20nModal");
+      window.dom.hide("erc20nInfo");
+      amount.value = "";
+      window.dom.find("erc20nSelectButton").classList.remove("selected");
+      window.dom.fill("erc20nSelectButton").with("Select token");
+      window.dom.hide("useMaxErc20n");
+      amount.disabled = true;
+    };
 
     function enableOrDisableErc20n() {
-      window.dom.show("useMaxErc20n")
-      const decimalBalance = window.Decimal(window.dom.find("erc20nBalance").innerHTML)
-      const decimalAmount = window.Decimal(amount.value)
-      if (decimalAmount.isZero() || decimalAmount.comparedTo(decimalBalance) === 1)
-        submit.disabled = true
-      else submit.disabled = false
+      window.dom.show("useMaxErc20n");
+      const decimalBalance = window.Decimal(
+        window.dom.find("erc20nBalance").innerHTML
+      );
+      const decimalAmount = window.Decimal(amount.value);
+      if (
+        decimalAmount.isZero() ||
+        decimalAmount.comparedTo(decimalBalance) === 1
+      )
+        submit.disabled = true;
+      else submit.disabled = false;
     }
     maxAmount.onclick = () => {
-      amount.value = window.dom.find("erc20nBalance").innerHTML
-      enableOrDisableErc20n()
-      window.dom.hide("useMaxErc20n")
-    }
+      amount.value = window.dom.find("erc20nBalance").innerHTML;
+      enableOrDisableErc20n();
+      window.dom.hide("useMaxErc20n");
+    };
 
-    amount.onkeyup = enableOrDisableErc20n
+    amount.onkeyup = enableOrDisableErc20n;
 
     window.dom.find(
       "sendBridgedNep141Form"
     ).onsubmit = async function transferErc20n(e) {
       e.preventDefault();
-      window.dom.show("startTransferToEthereumModal")
-    }
+      window.dom.show("startTransferToEthereumModal");
+    };
 
     confirmSubmit.onclick = async function confirmTransferErc20n(e) {
-      confirmSubmit.disabled = true
+      confirmSubmit.disabled = true;
       try {
         await window.nep141Xerc20.bridgedNep141.sendToEthereum({
           amount: amount.value,
@@ -214,15 +240,15 @@
         });
         // Client library will redirect to NEAR Wallet
       } catch (e) {
-        console.error(e)
+        console.error(e);
         alert(
           "Something went wrong! " +
             "Maybe you need to sign out and back in? " +
             "Check your browser console for more info."
         );
         // only hide if error, show until redirect happens
-        window.dom.hide("startTransferToEthereumModal")
-        confirmSubmit.disabled = false
+        window.dom.hide("startTransferToEthereumModal");
+        confirmSubmit.disabled = false;
       }
     };
 
@@ -233,16 +259,16 @@
     });
   });
 
-  function ownedErc20nOnTop (token1, token2) {
-    if (token1.nep141.balance === '0' && token2.nep141.balance !== '0') {
-      return 1
-    } else if (token1.nep141.balance !== '0' && token2.nep141.balance === '0') {
-      return -1
+  function ownedErc20nOnTop(token1, token2) {
+    if (token1.nep141.balance === "0" && token2.nep141.balance !== "0") {
+      return 1;
+    } else if (token1.nep141.balance !== "0" && token2.nep141.balance === "0") {
+      return -1;
     }
-    return 0
+    return 0;
   }
 
-  async function fillErc20nList () {
+  async function fillErc20nList() {
     if (!window.ethInitialized) return;
     if (!window.isValidEthNetwork) return;
     if (window.urlParams.get("erc20n") === null) return;
@@ -250,8 +276,10 @@
     const allTokens = await window.utils.getAllErc20s();
 
     window.dom.fill("erc20nList").with(
-      Object.values(allTokens).sort(ownedErc20nOnTop).map(
-        (token) => `
+      Object.values(allTokens)
+        .sort(ownedErc20nOnTop)
+        .map(
+          (token) => `
         <label class="space-between">
           <input
             type="radio"
@@ -268,7 +296,7 @@
           </span>
         </label>
       `
-      )
+        )
     );
   }
 
@@ -298,11 +326,11 @@
       window.dom.fill("erc20nSelectButton").with("Select token");
       window.dom.hide("erc20nInfo");
       window.dom.show("sendBridgedNep141");
-      window.dom.hide("useMaxErc20n")
+      window.dom.hide("useMaxErc20n");
       return;
     }
 
-    window.dom.show("useMaxErc20n")
+    window.dom.show("useMaxErc20n");
 
     let token;
     try {
@@ -326,7 +354,7 @@
     }
 
     // getErc20Data succeeded so remember this token if not already in storage
-    window.utils.rememberCustomErc20(erc20nAddress)
+    window.utils.rememberCustomErc20(erc20nAddress);
 
     if (token.nep141.balance === null) {
       window.dom.hide("sendBridgedNep141");
@@ -352,15 +380,17 @@
     if (token.nep141.balance) amount.disabled = false;
     else amount.disabled = true;
 
-    amount.step = Number(Decimal(10).pow(-token.decimals).toFixed())
+    amount.step = Number(Decimal(10).pow(-token.decimals).toFixed());
     // NOTE: the html input field makes the comparison on rounded numbers
     // So the max check is not precise for very small decimals.
     // For example if the balance is 500003.0100900000011, then the input field will allow a max of
     // only 500003.01009
     amount.max = Number(
-      new window.Decimal(token.nep141.balance).times(Decimal(10).pow(-token.decimals)).toFixed()
-    )
-    amount.min = Number(Decimal(10).pow(-token.decimals).toFixed())
+      new window.Decimal(token.nep141.balance)
+        .times(Decimal(10).pow(-token.decimals))
+        .toFixed()
+    );
+    amount.min = Number(Decimal(10).pow(-token.decimals).toFixed());
     window.dom.show("erc20nInfo", "flex");
     amount.focus();
   }


### PR DESCRIPTION
The current copy used for TXN modals is much too verbose. Whenever possible, we should try and be concise and provide only as much context as necessary, especially for intermediary states and messages.

These changes attempt to cut down on the amount of copy we use in each of this messaging since users are unlikely to read them in their entirety while moving through the transaction flow and between wallets.