### PR TITLE
fix(auth): fix provider not found when connecting to imtoken wallet

### DIFF
--- a/src/js/authEthereum.js
+++ b/src/js/authEthereum.js
@@ -41,7 +41,7 @@ async function login () {
   ))
   setSignerProvider(new ethers.providers.Web3Provider(provider, 'any'))
 
-  if (provider.isMetaMask) {
+  if (provider.isMetaMask || provider.isImToken) {
     window.ethUserAddress = provider.selectedAddress
     window.connectedEthNetwork = chainIdToEthNetwork[parseInt(provider.chainId)]
   } else {


### PR DESCRIPTION
## Issue Description

When opening Rainbow Bridge in the browser inside the [imToken wallet](https://token.im/), the wallet address will not be retrieved, making it impossible to proceed to the next step.

### How to Reproduce

1. open [imToken wallet](https://token.im/), redirect to *Browser* tab.
2. Type in `https://ethereum.bridgetonear.org/` into your internal browser and visit.
3. Click on the `Connect` button to observe this issue.

## Issue Source

The imToken wallet is injected with the exact same provider as the *metamask*, so we need to use the metamask linking method.

## Changes

- When using the imToken wallet, similar to the metamask, the provider carries the additional identifier `isImToken`.
- For any other wallets or logic, no effect.

PS: Rainbow Bridge is an amazing application, imToken Wallet has a lot of users who are using it. This fix will help all users who are using near in imToken, wait for updated news.

#### Before

<img width="697" alt="near-imtoken-1" src="https://user-images.githubusercontent.com/11304944/131286311-931be55f-166e-4857-acbf-5e8ca6a28350.png">

#### After

<img width="830" alt="near-imtoken-2" src="https://user-images.githubusercontent.com/11304944/131286331-88187103-27fe-4717-aeed-93ec1d89ef44.png">
